### PR TITLE
Bugfix/null or

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -335,17 +335,33 @@ final class Assert
                 call_user_func_array([static::class, $name], $arguments);
             } elseif (preg_match('/^nullOr(.*)$/i', $name, $matches)) {
                 $method = lcfirst($matches[1]);
-                if (method_exists(static::class, $method)) {
-                    call_user_func_array([static::class, 'nullOr'], [$method, $arguments]);
+                if (method_exists(Webmozart::class, $method)) {
+                    call_user_func_array([static::class, 'nullOr'], [[Webmozart::class, $method], $arguments]);
+                } elseif (method_exists(static::class, $method)) {
+                    call_user_func_array([static::class, 'nullOr'], [[static::class, $method], $arguments]);
                 } else {
-                    throw new BadMethodCallException($method);
+                    throw new BadMethodCallException(sprintf("Assertion named `%s` does not exists.", $method));
                 }
             } else {
-                throw new BadMethodCallException($name);
+                throw new BadMethodCallException(sprintf("Assertion named `%s` does not exists.", $name));
             }
         } catch (InvalidArgumentException $e) {
             throw new $exception($e->getMessage());
         }
+    }
+
+
+    /**
+     * Handle nullOr* for either Webmozart or for our custom assertions
+     *
+     * @param callable $method
+     * @param array $arguments
+     * @return void
+     */
+    private static function nullOr(callable $method, array $arguments): void
+    {
+        $value = reset($arguments);
+        ($value === null) || call_user_func_array($method, $arguments);
     }
 
 

--- a/src/Assert.php
+++ b/src/Assert.php
@@ -337,9 +337,11 @@ final class Assert
                 $method = lcfirst($matches[1]);
                 if (method_exists(static::class, $method)) {
                     call_user_func_array([static::class, 'nullOr'], [$method, $arguments]);
+                } else {
+                    throw new BadMethodCallException($method);
                 }
             } else {
-                throw new BadMethodCallException();
+                throw new BadMethodCallException($name);
             }
         } catch (InvalidArgumentException $e) {
             throw new $exception($e->getMessage());

--- a/src/CustomAssertionTrait.php
+++ b/src/CustomAssertionTrait.php
@@ -45,20 +45,6 @@ trait CustomAssertionTrait
 
 
     /**
-     * nullOr* for our custom assertions
-     *
-     * @param string $method
-     * @param array $arguments
-     * @return void
-     */
-    private static function nullOr(string $method, array $arguments): void
-    {
-        $value = reset($arguments);
-        ($value === null) || call_user_func_array([static::class, $method], $arguments);
-    }
-
-
-    /**
      * @param string $value
      */
     private static function validDuration(string $value, string $message = ''): void

--- a/tests/Assert/AssertTest.php
+++ b/tests/Assert/AssertTest.php
@@ -64,6 +64,15 @@ final class AssertTest extends TestCase
 
     /**
      */
+    public function testUnknownNullOrAssertionRaisesBadMethodCallException(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        Assert::nullOrThisAssertionDoesNotExist('a', 'b', LogicException::class);
+    }
+
+
+    /**
+     */
     public function testNullOrCustomAssertionWorks(): void
     {
         Assert::nullOrStringPlausibleBase64('U2ltcGxlU0FNTHBocA==');


### PR DESCRIPTION
Any nullOr* assertion that didn't exist would silently pass instead of throwing a BadMethodCallException.