### PR TITLE
composer reported updating:PHP Fatal error:  Cannot use ::class with dynamic class name...

### DIFF
--- a/src/Assert.php
+++ b/src/Assert.php
@@ -424,14 +424,14 @@ final class Assert
 
         if (is_object($value)) {
             if (method_exists($value, '__toString')) {
-                return $value::class . ': ' . self::valueToString($value->__toString());
+                return get_class($value) . ': ' . self::valueToString($value->__toString());
             }
 
             if ($value instanceof DateTime || $value instanceof DateTimeImmutable) {
-                return $value::class . ': ' . self::valueToString($value->format('c'));
+                return get_class($value) . ': ' . self::valueToString($value->format('c'));
             }
 
-            return $value::class;
+            return get_class($value);
         }
 
         if (is_string($value)) {


### PR DESCRIPTION
composer reported following error when updating:
PHP Fatal error:  Cannot use ::class with dynamic class name in /home/runner/work/INTER-Mediator/INTER-Mediator/vendor/simplesamlphp/assert/src/Assert.php on line 427.