### PR TITLE
Make regexps more strict and refuse trailing newlines

### DIFF
--- a/src/CustomAssertionTrait.php
+++ b/src/CustomAssertionTrait.php
@@ -23,22 +23,22 @@ use function substr;
 trait CustomAssertionTrait
 {
     /** @var string */
-    private static string $nmtoken_regex = '/^[\w.:-]+$/u';
+    private static string $nmtoken_regex = '/^[\w.:-]+$/Du';
 
     /** @var string */
-    private static string $nmtokens_regex = '/^([\w.:-]+)([\s][\w.:-]+)*$/u';
+    private static string $nmtokens_regex = '/^([\w.:-]+)([\s][\w.:-]+)*$/Du';
 
     /** @var string */
-    private static string $datetime_regex = '/-?[0-9]{4}-(((0(1|3|5|7|8)|1(0|2))-(0[1-9]|(1|2)[0-9]|3[0-1]))|((0(4|6|9)|11)-(0[1-9]|(1|2)[0-9]|30))|(02-(0[1-9]|(1|2)[0-9])))T([0-1][0-9]|2[0-4]):(0[0-9]|[1-5][0-9]):(0[0-9]|[1-5][0-9])(\.[0-999])?((\+|-)([0-1][0-9]|2[0-4]):(0[0-9]|[1-5][0-9])|Z)?/i';
+    private static string $datetime_regex = '/-?[0-9]{4}-(((0(1|3|5|7|8)|1(0|2))-(0[1-9]|(1|2)[0-9]|3[0-1]))|((0(4|6|9)|11)-(0[1-9]|(1|2)[0-9]|30))|(02-(0[1-9]|(1|2)[0-9])))T([0-1][0-9]|2[0-4]):(0[0-9]|[1-5][0-9]):(0[0-9]|[1-5][0-9])(\.[0-999])?((\+|-)([0-1][0-9]|2[0-4]):(0[0-9]|[1-5][0-9])|Z)?/Di';
 
     /** @var string */
-    private static string $duration_regex = '/^([-+]?)P(?!$)(?:(?<years>\d+(?:[\.\,]\d+)?)Y)?(?:(?<months>\d+(?:[\.\,]\d+)?)M)?(?:(?<weeks>\d+(?:[\.\,]\d+)?)W)?(?:(?<days>\d+(?:[\.\,]\d+)?)D)?(T(?=\d)(?:(?<hours>\d+(?:[\.\,]\d+)?)H)?(?:(?<minutes>\d+(?:[\.\,]\d+)?)M)?(?:(?<seconds>\d+(?:[\.\,]\d+)?)S)?)?$/';
+    private static string $duration_regex = '/^([-+]?)P(?!$)(?:(?<years>\d+(?:[\.\,]\d+)?)Y)?(?:(?<months>\d+(?:[\.\,]\d+)?)M)?(?:(?<weeks>\d+(?:[\.\,]\d+)?)W)?(?:(?<days>\d+(?:[\.\,]\d+)?)D)?(T(?=\d)(?:(?<hours>\d+(?:[\.\,]\d+)?)H)?(?:(?<minutes>\d+(?:[\.\,]\d+)?)M)?(?:(?<seconds>\d+(?:[\.\,]\d+)?)S)?)?$/D';
 
     /** @var string */
-    private static string $qname_regex = '/^[a-zA-Z_][\w.-]*:[a-zA-Z_][\w.-]*$/';
+    private static string $qname_regex = '/^[a-zA-Z_][\w.-]*:[a-zA-Z_][\w.-]*$/D';
 
     /** @var string */
-    private static string $ncname_regex = '/^[a-zA-Z_][\w.-]*$/';
+    private static string $ncname_regex = '/^[a-zA-Z_][\w.-]*$/D';
 
     /** @var string */
     private static string $base64_regex = '/^(?:[a-z0-9+\/]{4})*(?:[a-z0-9+\/]{2}==|[a-z0-9+\/]{3}=)?$/i';

--- a/src/CustomAssertionTrait.php
+++ b/src/CustomAssertionTrait.php
@@ -43,9 +43,6 @@ trait CustomAssertionTrait
     /** @var string */
     private static string $base64_regex = '/^(?:[a-z0-9+\/]{4})*(?:[a-z0-9+\/]{2}==|[a-z0-9+\/]{3}=)?$/i';
 
-    /** @var string */
-    private static string $hostname_regex = '/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/';
-
     /***********************************************************************************
      *  NOTE:  Custom assertions may be added below this line.                         *
      *         They SHOULD be marked as `private` to ensure the call is forced         *

--- a/tests/Assert/DurationTest.php
+++ b/tests/Assert/DurationTest.php
@@ -59,6 +59,8 @@ final class DurationTest extends TestCase
             [false, 'P2M1Y'],
             [false, 'P'],
             [false, 'PT15.S'],
+            // Trailing newlines are forbidden
+            [false, "P20M\n"],
         ];
     }
 }

--- a/tests/Assert/NCNameTest.php
+++ b/tests/Assert/NCNameTest.php
@@ -46,6 +46,8 @@ final class NCNameTest extends TestCase
             [false, 'Te*st'],
             [false, '1Test'],
             [false, 'Te:st'],
+            // Trailing newlines are forbidden
+            [false, "Test\n"],
         ];
     }
 }

--- a/tests/Assert/NMTokenTest.php
+++ b/tests/Assert/NMTokenTest.php
@@ -49,6 +49,8 @@ final class NMTokenTest extends TestCase
             [false, 'foo bar'],
             // Commas are forbidden
             [false, 'foo,bar'],
+            // Trailing newlines are forbidden
+            [false, "foobar\n"],
         ];
     }
 }

--- a/tests/Assert/NMTokensTest.php
+++ b/tests/Assert/NMTokensTest.php
@@ -50,6 +50,8 @@ final class NMTokensTest extends TestCase
             [false, 'foo "bar" baz'],
             // Commas are forbidden
             [false, 'foo,bar'],
+            // Trailing newlines are forbidden
+            [false, "foobar\n"],
         ];
     }
 }

--- a/tests/Assert/QNameTest.php
+++ b/tests/Assert/QNameTest.php
@@ -46,6 +46,8 @@ final class QNameTest extends TestCase
             [true, 'Test'],
             [false, '1Test'],
             [false, 'Te*st'],
+            // Trailing newlines are forbidden
+            [false, "some:Test\n"],
         ];
     }
 }


### PR DESCRIPTION
This was triggered by https://github.com/webmozarts/assert/issues/307